### PR TITLE
Use ipfs-pubsub-room

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "orbit-db-pubsub",
+  "version": "0.2.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "debug": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
+      "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "hyperdiff": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hyperdiff/-/hyperdiff-2.0.3.tgz",
+      "integrity": "sha512-NAJxMV58m7Riefe0HAVt6gQx9KgRrYIBdd2dKLZ0wzdyNJlwO3gNPt8SXNxh8VrO5eOrp3ipdOePpPdPircKLw==",
+      "requires": {
+        "debug": "3.0.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.pullat": "4.6.0"
+      }
+    },
+    "ipfs-pubsub-room": {
+      "version": "github:haadcode/ipfs-pubsub-room#abc74650fc57a22ce0c31754b9667a6948e549d0",
+      "requires": {
+        "hyperdiff": "2.0.3",
+        "lodash.clonedeep": "4.5.0",
+        "pull-pushable": "2.1.1",
+        "pull-stream": "3.6.1",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.pullat": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pullat/-/lodash.pullat-4.6.0.tgz",
+      "integrity": "sha1-vfrPDiCf0n+WXnEfplp3SoTTAmE="
+    },
+    "logplease": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/logplease/-/logplease-1.2.14.tgz",
+      "integrity": "sha512-n6bf1Ce0zvcmuyOzDi2xxLix6F1D/Niz7Qa4K3BmkjyaXcovzEjwZKUYsV+0F2Uv4rlXm5cToIEB+ynqSRdwGw=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "pull-pushable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.1.1.tgz",
+      "integrity": "sha1-hmZqu+P1QC8ffq0D7v1pt4Xspbg="
+    },
+    "pull-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.1.tgz",
+      "integrity": "sha1-xcKuSlEkbv7rzGXAQSo9clqSzgA="
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Haad",
   "license": "MIT",
   "dependencies": {
+    "ipfs-pubsub-room": "haadcode/ipfs-pubsub-room#fix/race-on-start",
     "logplease": "~1.2.14"
   }
 }


### PR DESCRIPTION
This PR will change the OrbitDB pubsub wrapper to use [ipfs-pubsub-room](https://github.com/ipfs-shipyard/ipfs-pubsub-room) through which we get "peer joined" and "peer left" events as well as the ability to send a direct message to a peer.

- Use ipfs-pubsub-room
- Add a callback to know when connected to new peers
- Log ipfs-pubsub-room errors
- Keep count of open topics
- Add ipfs-pubsub-room fixes