### PR TITLE
Use ipfs-pubsub-room v1.2.0 instead of our fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,12 +23,14 @@
       }
     },
     "ipfs-pubsub-room": {
-      "version": "github:haadcode/ipfs-pubsub-room#68aecffc0c89b2430349d59c2556c0f70b2f96e5",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ipfs-pubsub-room/-/ipfs-pubsub-room-1.2.0.tgz",
+      "integrity": "sha512-NPAyPF670n4S8Mse7wodVbbzxPwHVgHKV0QqIliO4NM8u88kZhttPi1/jume9MLtqAIgleSrnrYZ6qqaaoRP1A==",
       "requires": {
         "hyperdiff": "2.0.4",
         "lodash.clonedeep": "4.5.0",
-        "pull-pushable": "2.1.1",
-        "pull-stream": "3.6.1",
+        "pull-pushable": "2.2.0",
+        "pull-stream": "3.6.2",
         "safe-buffer": "5.1.1"
       }
     },
@@ -53,14 +55,14 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "pull-pushable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.1.1.tgz",
-      "integrity": "sha1-hmZqu+P1QC8ffq0D7v1pt4Xspbg="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
     },
     "pull-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.1.tgz",
-      "integrity": "sha1-xcKuSlEkbv7rzGXAQSo9clqSzgA="
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.2.tgz",
+      "integrity": "sha1-HqFMbxMXTmrE3vDCpOdlZ7fLDFw="
     },
     "safe-buffer": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Haad",
   "license": "MIT",
   "dependencies": {
-    "ipfs-pubsub-room": "github:haadcode/ipfs-pubsub-room#orbitdb",
+    "ipfs-pubsub-room": "~1.2.0",
     "logplease": "~1.2.14"
   }
 }


### PR DESCRIPTION
This PR will remove the ipfs-pubsub-room fork we made back in the days and will use the official version from npm at version 1.2.0.