### PR TITLE
Use ipfs-pubsub-peer-monitor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,16 +22,12 @@
         "lodash.pullat": "4.6.0"
       }
     },
-    "ipfs-pubsub-room": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ipfs-pubsub-room/-/ipfs-pubsub-room-1.2.0.tgz",
-      "integrity": "sha512-NPAyPF670n4S8Mse7wodVbbzxPwHVgHKV0QqIliO4NM8u88kZhttPi1/jume9MLtqAIgleSrnrYZ6qqaaoRP1A==",
+    "ipfs-pubsub-peer-monitor": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-pubsub-peer-monitor/-/ipfs-pubsub-peer-monitor-0.0.1.tgz",
+      "integrity": "sha512-J+dxnPrj4p3nu3ViJWVbIhM6TDddlF0nZ8H+EycLrnibiRqTjSlcNPm0FHMqRsneaq0gi6yJA9Ksv3Cy09jkjg==",
       "requires": {
-        "hyperdiff": "2.0.4",
-        "lodash.clonedeep": "4.5.0",
-        "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.2",
-        "safe-buffer": "5.1.1"
+        "hyperdiff": "2.0.4"
       }
     },
     "lodash.clonedeep": {
@@ -53,21 +49,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "pull-pushable": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
-    },
-    "pull-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.2.tgz",
-      "integrity": "sha1-HqFMbxMXTmrE3vDCpOdlZ7fLDFw="
-    },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Haad",
   "license": "MIT",
   "dependencies": {
-    "ipfs-pubsub-room": "~1.2.0",
+    "ipfs-pubsub-peer-monitor": "0.0.1",
     "logplease": "~1.2.14"
   }
 }


### PR DESCRIPTION
This PR will replace ipfs-pubsub-room module with ipfs-pubsub-peer-monitor module. 

ipfs-pubsub-room contains extra functionality that are not needed for knowing when peers join/leave a topic and it doesn't work with js-ipfs-api (go-ipfs) as it uses libp2p internally. Created [ipfs-pubsub-peer-monitor](https://github.com/haadcode/ipfs-pubsub-peer-monitor) to simplify the monitoring of a topic and to Do One Thing and pulling it in here.