### PR TITLE
fix: make unsubscribe/disconnect async

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,27 @@ npm install orbit-db-pubsub
 
 ### API
 
-#### subscribe(topic, callback)
+#### subscribe(topic, onMessageHandler, onNewPeerHandler, [callback])
 
 Listen for new messages in `topic`
 
-`callback` gets called when a message is received with signature `(topic, data)`
+`onMessageHandler` gets called when a message is received with signature `(topic, data)`
 
-#### unsubscribe(topic)
+`onNewPeerHandler` gets called when a new peer joins with signature `(topic, peer)`
+
+If no `callback` is provided, a promise is returned.
+
+#### unsubscribe(topic, [callback])
 
 Stop listening for new messages in `topic`
+
+If no `callback` is provided, a promise is returned
+
+#### disconnect ([callback])
+
+Stop listening for new messages in all topics
+
+If no `callback` is provided, a promise is returned
 
 #### publish(topic, data)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,13 +4,26 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
     "ipfs-pubsub-peer-monitor": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/ipfs-pubsub-peer-monitor/-/ipfs-pubsub-peer-monitor-0.0.5.tgz",
       "integrity": "sha512-N+yBjG4tQNO6TFslDSCjdxY5cYgJGq8nhWjS77+rooUFVTCp8VbAODC6jsFoM0A7bS6kA8MbW3ee6VNu00QX9g==",
       "requires": {
-        "p-forever": "1.0.1"
+        "p-forever": "^1.0.1"
       }
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "logplease": {
       "version": "1.2.14",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Haad",
   "license": "MIT",
   "dependencies": {
+    "async": "^2.6.1",
     "ipfs-pubsub-peer-monitor": "~0.0.5",
     "logplease": "~1.2.14"
   }

--- a/src/ipfs-pubsub.js
+++ b/src/ipfs-pubsub.js
@@ -1,10 +1,13 @@
 'use strict'
 
 const PeerMonitor = require('ipfs-pubsub-peer-monitor')
+const async = require('async')
 
 const Logger = require('logplease')
 const logger = Logger.create("pubsub", { color: Logger.Colors.Yellow })
 Logger.setLogLevel('ERROR')
+
+const noop = (err) => { if (err) throw err }
 
 const maxTopicsOpen = 256
 let topicsOpenCount = 0
@@ -26,48 +29,83 @@ class IPFSPubsub {
       this._ipfs.setMaxListeners(maxTopicsOpen)
   }
 
-  subscribe(topic, onMessageCallback, onNewPeerCallback) {
-    if(!this._subscriptions[topic] && this._ipfs.pubsub) {
-      this._ipfs.pubsub.subscribe(topic, this._handleMessage, (err, res) => {
-        if (err) throw err
-
-        const topicMonitor = new PeerMonitor(this._ipfs.pubsub, topic)
-
-        topicMonitor.on('join', (peer) => {
-          logger.debug(`Peer joined ${topic}:`)
-          logger.debug(peer)
-          if (this._subscriptions[topic]) {
-            onNewPeerCallback(topic, peer)
-          } else {
-            logger.warn('Peer joined a room we don\'t have a subscription for')
-            logger.warn(topic, peer)
-          }
-        })
-
-        topicMonitor.on('leave', (peer) => logger.debug(`Peer ${peer} left ${topic}`))
-        topicMonitor.on('error', (e) => logger.error(e))
-
-        this._subscriptions[topic] = {
-          topicMonitor: topicMonitor,
-          onMessage: onMessageCallback,
-          onNewPeer: onNewPeerCallback 
-        }
-
-        topicsOpenCount ++
-        logger.debug("Topics open:", topicsOpenCount)
-      })
+  subscribe(topic, onMessageCallback, onNewPeerCallback, callback = noop) {
+    if (this._subscriptions[topic]) {
+      logger.warn(`Subscription already exists: ${topic}`)
+      return callback()
     }
+
+    if (!this._ipfs.pubsub) {
+      logger.warn('IPFS pubsub is not active')
+      return callback()
+    }
+
+    this._ipfs.pubsub.subscribe(topic, this._handleMessage, (err, res) => {
+      if (err) {
+        return callback(err)
+      }
+
+      const topicMonitor = new PeerMonitor(this._ipfs.pubsub, topic)
+
+      topicMonitor.on('join', (peer) => {
+        logger.debug(`Peer joined ${topic}:`)
+        logger.debug(peer)
+        if (this._subscriptions[topic]) {
+          onNewPeerCallback(topic, peer)
+        } else {
+          logger.warn('Peer joined a room we don\'t have a subscription for')
+          logger.warn(topic, peer)
+        }
+      })
+
+      topicMonitor.on('leave', (peer) => logger.debug(`Peer ${peer} left ${topic}`))
+      topicMonitor.on('error', (e) => logger.error(e))
+
+      this._subscriptions[topic] = {
+        topicMonitor: topicMonitor,
+        onMessage: onMessageCallback,
+        onNewPeer: onNewPeerCallback
+      }
+
+      topicsOpenCount ++
+      logger.debug('Topics open:', topicsOpenCount)
+
+      callback()
+    })
   }
 
-  unsubscribe(hash) {
-    if(this._subscriptions[hash]) {
-      this._ipfs.pubsub.unsubscribe(hash, this._handleMessage)
+  unsubscribe (hash, callback) {
+    if (!callback) {
+      return new Promise((resolve, reject) => {
+        this._unsubscribe(hash, (err) => {
+          if (err) {
+            return reject(err)
+          }
+          resolve()
+        })
+      })
+    }
+
+    this._unsubscribe(hash, callback)
+  }
+  _unsubscribe (hash, callback) {
+    if (!this._subscriptions[hash]) {
+      logger.warn(`Subscription doesn't exist: ${hash}`)
+      return callback()
+    }
+
+    this._ipfs.pubsub.unsubscribe(hash, this._handleMessage, (err) => {
+      if (err) {
+        return callback(err)
+      }
       this._subscriptions[hash].topicMonitor.stop()
       delete this._subscriptions[hash]
       logger.debug(`Unsubscribed from '${hash}'`)
       topicsOpenCount --
       logger.debug("Topics open:", topicsOpenCount)
-    }
+
+      callback()
+    })
   }
 
   publish(topic, message) {
@@ -76,13 +114,32 @@ class IPFSPubsub {
     }
   }
 
-  disconnect() {
-    Object.keys(this._subscriptions)
-      .forEach((e) => this.unsubscribe(e))
+  disconnect (callback) {
+    if (!callback) {
+      return new Promise((resolve, reject) => {
+        this._disconnect((err) => {
+          if (err) {
+            return reject(err)
+          }
+          resolve()
+        })
+      })
+    }
 
-    this._subscriptions = {}
+    this._disconnect(callback)
   }
 
+  _disconnect (callback) {
+    const subscriptions = Object.keys(this._subscriptions)
+    async.eachSeries(subscriptions, this.unsubscribe.bind(this), (err) => {
+      if (err) {
+        return callback(err)
+      }
+
+      this._subscriptions = {}
+      callback()
+    })
+  }
 
   _handleMessage(message) {
     // Don't process our own messages

--- a/src/ipfs-pubsub.js
+++ b/src/ipfs-pubsub.js
@@ -77,7 +77,7 @@ class IPFSPubsub {
 
   async disconnect() {
     const topics = Object.keys(this._subscriptions)
-    await pSeries(topics.map(this.unsubscribe))
+    await pSeries(topics.map((t) => this.unsubscribe.bind(this, t)))
     this._subscriptions = {}
   }
 


### PR DESCRIPTION
Update `IPFSPubsub.unsubscribe` and `IPFSPubsub.disconnect` to be async as [js-ipfs-api has updated `pubsub.unsubscribe` to be async](https://github.com/ipfs/js-ipfs-api/blob/master/CHANGELOG.md#breaking-changes).

`IPFSPubsub.unsubscribe` and `IPFSPubsub.disconnect` can be used with callbacks or if no callback is provided it will return a promise so that you can use `async/await`.

I also updated `IPFSPubsub.subscribe` to receive an optional callback - otherwise it will throw an error, like before.

potentially related: orbitdb/orbit-db#370