### PR TITLE
add options parameter to publish and subscribe

### DIFF
--- a/src/ipfs-pubsub.js
+++ b/src/ipfs-pubsub.js
@@ -27,9 +27,9 @@ class IPFSPubsub {
       this._ipfs.setMaxListeners(maxTopicsOpen)
   }
 
-  async subscribe(topic, onMessageCallback, onNewPeerCallback) {
+  async subscribe(topic, onMessageCallback, onNewPeerCallback, options = {}) {
     if(!this._subscriptions[topic] && this._ipfs.pubsub) {
-      await this._ipfs.pubsub.subscribe(topic, this._handleMessage)
+      await this._ipfs.pubsub.subscribe(topic, this._handleMessage, options)
 
       const topicMonitor = new PeerMonitor(this._ipfs.pubsub, topic)
 
@@ -69,9 +69,9 @@ class IPFSPubsub {
     }
   }
 
-  publish(topic, message) {
+  publish(topic, message, options = {}) {
     if(this._subscriptions[topic] && this._ipfs.pubsub) {
-      this._ipfs.pubsub.publish(topic, Buffer.from(JSON.stringify(message)))
+      this._ipfs.pubsub.publish(topic, Buffer.from(JSON.stringify(message)), options)
     }
   }
 


### PR DESCRIPTION
This is useful for use with `ipfs-http-client`, where the options parameter allows additional control (https://github.com/ipfs/js-ipfs-http-client#additional-options)

Our specific use-case is catching errors by being able to pass in an `onError` handler as well as using the `AbortSignal` to cancel requests. Using these we can try reopening the subscribe request if the connection between orbit-db and the ipfs host is lost.