### PR TITLE
feat: allow non json data types to be used.

### DIFF
--- a/src/ipfs-pubsub.js
+++ b/src/ipfs-pubsub.js
@@ -71,11 +71,12 @@ class IPFSPubsub {
 
   publish(topic, message, options = {}) {
     if (this._subscriptions[topic] && this._ipfs.pubsub) {
-      var payload;
-      if(typeof message === "object") {
-        payload = JSON.stringify(message);
-      } else {
+      let payload;
+      //Buffer should be already serialized. Everything else will get serialized as json if not buffer, string.
+      if(Buffer.isBuffer(message) | typeof message === "string") {
         payload = message;
+      } else {
+        payload = JSON.stringify(message);
       }
       this._ipfs.pubsub.publish(topic, Buffer.from(payload), options)
     }


### PR DESCRIPTION
Allows other data serializations as specified by higher level code to be used. No longer forces json serialization. Support is backwards compatible is detected as object for publish or detected as JSON for receiving end.