### PR TITLE
Fix TypeError with IPFSPubsub.

### DIFF
--- a/src/ipfs-pubsub.js
+++ b/src/ipfs-pubsub.js
@@ -97,7 +97,7 @@ class IPFSPubsub {
     let content, subscription, topicId
 
     // Get the topic
-    topicId = message.topicIDs[0]
+    topicId = message.topic
     try {
       content = JSON.parse(Buffer.from(message.data).toString())
     } catch {


### PR DESCRIPTION
This fixes a type error when attempting to `put()` something to a database. 
```
TypeError: Cannot read properties of undefined (reading '0')
    at IPFSPubsub._handleMessage
```
[See here](https://github.com/orbitdb/orbit-db/pull/1004#issuecomment-1155276517).